### PR TITLE
added ros2_control support with keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,21 @@ SCR 2022-23's general systems; General range components used in different rover 
 
 Install dependencies and tools using systems_setup.bash
 
+rviz2 -d src/systems_2022_23/helios/config/view_bot.rviz
+
 Visualize URDF Rover
 	(from ros2_ws)
 	Terminal 1 (robot state publisher): ros2 launch helios rsp.launch.py
 	Terminal 2 (robot visualizer): rviz2 -d src/systems_2022_23/helios/config/view_bot.rviz
 	Terminal 3 (joint state emulator): ros2 run joint_state_publisher_gui joint_state_publisher_gui
 
-Run Simulation
+Run Simulation and Control Rover
 	(from ros2_ws)
 	Terminal 1 (robot state publisher + simulation): ros2 launch helios gazebo_sim.launch.py
 	Terminal 2 (robot visualizer): rviz2 -d src/systems_2022_23/helios/config/view_bot.rviz
+	Terminal 3 (keyboard controller): ros2 run ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r /cmd_vel:=/diff_cont/cmd_vel_unstamped
+
+
+Run keyboard controller
+	(from ros2_ws)
+

--- a/helios/config/my_controllers.yaml
+++ b/helios/config/my_controllers.yaml
@@ -4,26 +4,27 @@ controller_manager:
     use_sim_time: true
   
     diff_cont:
-      type: diff_drive/controller/DiffDriveController
+      type: diff_drive_controller/DiffDriveController
     
     joint_broad:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 diff_cont:
-
-  publish_rate: 50.0
-
-  base_frame_id: base_link
-
-  left_wheel_names: ['front_left_wheel_joint', 'back_left_wheel_joint']
-  right_wheel_names: ['front_right_wheel_joint', 'back_right_wheel_joint']
-  wheel_separation: 1.52
-  wheel_radius: 0.194
-
-  use_stamped_vel: false
-
-  wheels_per_side: 2
-
-
-joint_broad:
   ros__parameters:
+
+    publish_rate: 50.0
+
+    base_frame_id: base_link
+
+    left_wheel_names: ['front_left_wheel_joint', 'back_left_wheel_joint']
+    right_wheel_names: ['front_right_wheel_joint', 'back_right_wheel_joint']
+    wheel_separation: 1.52
+    wheel_radius: 0.194
+
+    use_stamped_vel: false
+
+    wheels_per_side: 2
+
+
+# joint_broad:
+#   ros__parameters:

--- a/helios/config/view_bot.rviz
+++ b/helios/config/view_bot.rviz
@@ -69,6 +69,8 @@ Visualization Manager:
           Value: true
         front_right_wheel_link:
           Value: true
+        odom:
+          Value: true
         zed2i_link:
           Value: true
         zed2i_link_optical:
@@ -79,20 +81,21 @@ Visualization Manager:
       Show Axes: true
       Show Names: true
       Tree:
-        base_link:
-          back_left_wheel_link:
-            {}
-          back_right_wheel_link:
-            {}
-          chassis_link:
-            camera_pole_link:
-              zed2i_link:
-                zed2i_link_optical:
-                  {}
-          front_left_wheel_link:
-            {}
-          front_right_wheel_link:
-            {}
+        odom:
+          base_link:
+            back_left_wheel_link:
+              {}
+            back_right_wheel_link:
+              {}
+            chassis_link:
+              camera_pole_link:
+                zed2i_link:
+                  zed2i_link_optical:
+                    {}
+            front_left_wheel_link:
+              {}
+            front_right_wheel_link:
+              {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -181,7 +184,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_link
+    Fixed Frame: odom
     Frame Rate: 30
   Name: root
   Tools:
@@ -224,25 +227,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 2.0188064575195312
+      Distance: 26.88243865966797
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.40894705057144165
-        Y: 0.08771190792322159
-        Z: 0.4017416834831238
+        X: -0.5977222323417664
+        Y: -0.606639564037323
+        Z: 0.8176233172416687
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.31520241498947144
+      Pitch: 0.735201895236969
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.725404679775238
+      Yaw: 3.1154232025146484
     Saved: ~
 Window Geometry:
   Displays:

--- a/helios/description/robot.urdf.xacro
+++ b/helios/description/robot.urdf.xacro
@@ -7,7 +7,6 @@
 
     <xacro:include filename="gazebo.xacro"/> 
 
-    <!-- <xacro:include filename="ros2_control.xacro"/> -->
-    <!-- <xacro:include filename="lidar.xacro"/> -->
+    <xacro:include filename="ros2_control.xacro"/>
 
 </robot>

--- a/helios/description/ros2_control.xacro
+++ b/helios/description/ros2_control.xacro
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:property name="min_vel" value="-10"/>
-    <xacro:property name="max_vel" value="10"/>
+    <!-- <xacro:property name="min_vel" value="-10"/>
+    <xacro:property name="max_vel" value="10"/> -->
 
     <!-- hardware interface for controller manager -->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <!-- change to work with ignition-->
             <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </hardware>
-        <!-- LEFT WHEEL -->
+        
+        <!-- LEFT WHEELS -->
+        <!-- front left wheel -->
         <joint name="front_left_wheel_joint">
             <command_interface name="velocity">
                 <param name="min">-10</param>
@@ -19,8 +20,28 @@
             <state_interface name="velocity"/>
             <state_interface name="position"/>
         </joint>
-        <!-- RIGHT WHEEL -->
+        <!-- back left wheel -->
+        <joint name="back_left_wheel_joint">
+            <command_interface name="velocity">
+                <param name="min">-10</param>
+                <param name="max">10</param>
+            </command_interface>
+            <state_interface name="velocity"/>
+            <state_interface name="position"/>
+        </joint>
+
+        <!-- RIGHT WHEELS -->
+        <!-- front right wheel -->
         <joint name="front_right_wheel_joint">
+            <command_interface name="velocity">
+                <param name="min">-10</param>
+                <param name="max">10</param>
+            </command_interface>
+            <state_interface name="velocity"/>
+            <state_interface name="position"/>
+        </joint>
+        <!-- back right wheel -->
+        <joint name="back_right_wheel_joint">
             <command_interface name="velocity">
                 <param name="min">-10</param>
                 <param name="max">10</param>
@@ -34,9 +55,8 @@
     <!-- when not using Gazebo, we need to run: -->
     <!-- ros2 run controller_manager ros2_control_node -->
     <gazebo>
-        <!-- change to work with ignition-->
         <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-            <parameters>$(find helios)/confog/my_controllers.yaml</parameters>
+            <parameters>$(find helios)/config/my_controllers.yaml</parameters>
         </plugin>
     </gazebo>
 

--- a/helios/launch/gazebo_sim.launch.py
+++ b/helios/launch/gazebo_sim.launch.py
@@ -34,33 +34,30 @@ def generate_launch_description():
 
     # Run the spawner node from the gazebo_ros package. The entity name
     # doesn't really matter if you only have a single robot.
-    # NOTE: need to change to work with ignition
     spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
                         arguments=['-topic', 'robot_description',
                                    '-entity', 'helios'],
                         output='screen')
 
-    # #NOTE not currently working
-    # # Run spawner node for differential drive controller
-    # diff_drive_spawner = Node(
-    #     package='controller_manager',
-    #     executable='spawner.py',
-    #     arguments=['diff_cont'],
-    # )
+    # Run spawner node for differential drive controller
+    diff_drive_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['diff_cont'],
+    )
 
-    # #NOTE not currently working
-    # # Run spawner node for joint broadcaster
-    # joint_broad_spawner = Node(
-    #     package='controller_manager',
-    #     executable='spawner.py',
-    #     arguments=['joint_broad'],
-    # )
+    # Run spawner node for joint broadcaster
+    joint_broad_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_broad'],
+    )
 
     # Launch them all!
     return LaunchDescription([
         rsp,
         gazebo,
         spawn_entity,
-        # diff_drive_spawner,
-        # joint_broad_spawner,
+        diff_drive_spawner,
+        joint_broad_spawner,
     ])

--- a/ros2_setup.bash
+++ b/ros2_setup.bash
@@ -27,6 +27,7 @@ sudo apt-get upgrade -y
 sudo apt install python3-colcon-common-extensions -y
 sudo apt install ros-humble-desktop -y
 sudo apt install python3-rosdep2 -y
+rosdep update
 
 
 # Set up ROS environment
@@ -40,3 +41,7 @@ echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.b
 
 # Install git
 sudo apt install git -y
+
+
+
+##FOR DRIVE - separate into separate bash script##

--- a/systems_setup.bash
+++ b/systems_setup.bash
@@ -6,3 +6,13 @@ sudo apt install ros-humble-gazebo-ros-pkgs -y
 # Install xacro and joint state publisher GUI
 sudo apt install ros-humble-xacro -y
 sudo apt install ros-humble-joint-state-publisher-gui -y
+
+# Install ros2 control
+sudo apt install ros-humble-ros2-control ros-humble-ros2-controllers ros-humble-gazebo-ros2-control -y
+
+
+
+
+
+# Install any missing dependencies
+rosdep install --from-paths src --ignore-src -r -y


### PR DESCRIPTION
Simulation is now controllable with ROS2 control. gazebo_sim launch file launches simulation with ROS2 control. To use, start teleop keyboard with command in readme "run simulation and rover control" section. Make sure to install ros2_control before starting, specific command can be found in systems_setup.bash